### PR TITLE
Allow Environment Variables from Config Maps and Secrets

### DIFF
--- a/charts/durabletask-azurestorage-scaler/Chart.yaml
+++ b/charts/durabletask-azurestorage-scaler/Chart.yaml
@@ -17,17 +17,13 @@ name: durabletask-azurestorage-scaler
 sources:
   - https://github.com/wsugarman/durabletask-azurestorage-scaler
 type: application
-version: "1.0.0"
+version: "1.1.0"
 
 annotations:
   artifacthub.io/category: monitoring-logging
   artifacthub.io/changes: |
     - kind: added
-      description: Added TLS support
-    - kind: changed
-      description: Updated NuGet dependencies
-    - kind: security
-      description: Updated dotnet/aspnet base image
+      description: Added support for environment variables from config maps and secrets
   artifacthub.io/containsSecurityUpdates: "true"
   artifacthub.io/images: |
     - name: durabletask-azurestorage-scaler

--- a/charts/durabletask-azurestorage-scaler/README.md
+++ b/charts/durabletask-azurestorage-scaler/README.md
@@ -46,6 +46,7 @@ The following table contains the possible set of configurations and their defaul
 | `additionalAnnotations`                       | `object`  | Additional annotations to add to all of the chart's resources                | `{}`                                                |
 | `additionalLabels`                            | `object`  | Additional labels to add to all of the chart's resources                     | `{}`                                                |
 | `env`                                         | `array`   | Additional environment variables that will be passed into the scaler pods    | `[]`                                                |
+| `envFrom`                                     | `array`   | Additional sources of environment variables available in the scaler pods     | `[]`                                                |
 | `fullnameOverride`                            | `string`  | Overrides the object name and the name in the `app.kubernetes.io/name` label |                                                     |
 | `image.pullPolicy`                            | `string`  | Scaler gRPC service image pull policy                                        | `IfNotPresent`                                      |
 | `image.pullSecrets`                           | `array`   | Scaler gRPC service image pull secrets                                       | `[]`                                                |

--- a/charts/durabletask-azurestorage-scaler/templates/02-deployment.yaml
+++ b/charts/durabletask-azurestorage-scaler/templates/02-deployment.yaml
@@ -84,6 +84,10 @@ spec:
             {{- toYaml .Values.env | nindent 12 -}}
             {{- end }}
           {{- end }}
+          {{- if .Values.envFrom }}
+          envFrom:
+            {{- toYaml .Values.envFrom | nindent 12 -}}
+          {{- end }}
           {{- if .Values.tls.secret }}
           volumeMounts:
             - name: certs

--- a/charts/durabletask-azurestorage-scaler/values.yaml
+++ b/charts/durabletask-azurestorage-scaler/values.yaml
@@ -85,6 +85,12 @@ env:
 # - name: ENV_NAME
 #   value: 'ENV-VALUE'
 
+envFrom:
+# - secretRef:
+#     name: secret-name
+# - configMapRef:
+#     name: config-map-name
+
 # Security context for the scaler container
 securityContext:
   capabilities:


### PR DESCRIPTION
The scaler chart now supports the use of Kubernetes config maps and secrets for environments to help users who may want to share connection strings between the scaler and their DTFx applications.

- Add `envFrom` to Values.yaml
- Bump chart version to `1.1.0`

Resolves https://github.com/wsugarman/durabletask-azurestorage-scaler/issues/219