### PR TITLE
Improve Integration Test Failure Diagnostics

### DIFF
--- a/.github/actions/helm-test/action.yml
+++ b/.github/actions/helm-test/action.yml
@@ -235,17 +235,17 @@ runs:
     - name: Get Keda Logs
       shell: bash
       if: ${{ failure() }}
-      run: kubectl logs -l app=keda-operator -n keda
+      run: kubectl logs --tail=-1 --prefix -l app=keda-operator -n keda
 
     - name: Get Scaler Logs
       shell: bash
       if: ${{ failure() }}
-      run: kubectl logs -l app=dtfx-scaler -n keda
+      run: kubectl logs --tail=-1 --prefix -l app=dtfx-scaler -n keda
 
     - name: Get Function Logs
       shell: bash
       if: ${{ failure() }}
-      run: kubectl logs -l app=${{ inputs.functionAppName }} -n ${{ inputs.functionAppNamespace }}
+      run: kubectl logs --tail=-1 --prefix -l app=${{ inputs.functionAppName }} -n ${{ inputs.functionAppNamespace }}
 
     - name: Uninstall Function App Helm Chart
       shell: bash

--- a/tests/Keda.Scaler.DurableTask.AzureStorage.Test.Integration/ScaleTest.cs
+++ b/tests/Keda.Scaler.DurableTask.AzureStorage.Test.Integration/ScaleTest.cs
@@ -122,7 +122,7 @@ public sealed class ScaleTest : IAsyncDisposable
         }
         catch (Exception)
         {
-            _ = await TryTerminateAsync(instanceId, linkedSource.Token).ConfigureAwait(false);
+            _ = await TryTerminateAsync(instanceId).ConfigureAwait(false);
             throw;
         }
 
@@ -165,7 +165,7 @@ public sealed class ScaleTest : IAsyncDisposable
         }
         catch (Exception e) when (e is not AssertFailedException)
         {
-            _ = await Task.WhenAll(instanceIds.Select(id => TryTerminateAsync(id, linkedSource.Token))).ConfigureAwait(false);
+            _ = await Task.WhenAll(instanceIds.Select(TryTerminateAsync)).ConfigureAwait(false);
             throw;
         }
 
@@ -278,11 +278,11 @@ public sealed class ScaleTest : IAsyncDisposable
     }
 
     [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Ignore errors as this is a test clean up.")]
-    private async Task<bool> TryTerminateAsync(string instanceId, CancellationToken cancellationToken)
+    private async Task<bool> TryTerminateAsync(string instanceId)
     {
         try
         {
-            await _durableClient.TerminateInstanceAsync(instanceId, cancellationToken).ConfigureAwait(false);
+            await _durableClient.TerminateInstanceAsync(instanceId, CancellationToken.None).ConfigureAwait(false);
             _logger.TerminatedOrchestration(instanceId);
             return true;
         }


### PR DESCRIPTION
- Fix bug where only 10 lines of container logs were output for test failures
- Do not pass token when trying to terminate orchestrations in test