### PR TITLE
Allow Certificate Readers to Update Certificate

### DIFF
--- a/src/Keda.Scaler.DurableTask.AzureStorage/Security/CertificateFileChangedEventArgs.cs
+++ b/src/Keda.Scaler.DurableTask.AzureStorage/Security/CertificateFileChangedEventArgs.cs
@@ -2,14 +2,11 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Runtime.ExceptionServices;
-using System.Security.Cryptography.X509Certificates;
+using System.IO;
 
 namespace Keda.Scaler.DurableTask.AzureStorage.Security;
 
 internal class CertificateFileChangedEventArgs : EventArgs
 {
-    public X509Certificate2? Certificate { get; init; }
-
-    public ExceptionDispatchInfo? Exception { get; init; }
+    public WatcherChangeTypes ChangeType { get; init; }
 }


### PR DESCRIPTION
If the state of the certificate is in error, readers can still trigger a refresh in hopes to successfully loading the value