### PR TITLE
Migrate Integration Azure Functions to .NET 8

### DIFF
--- a/tests/Keda.Scaler.Functions.Worker.DurableTask.Examples/Dockerfile
+++ b/tests/Keda.Scaler.Functions.Worker.DurableTask.Examples/Dockerfile
@@ -11,17 +11,8 @@ FROM build AS publish
 ARG BUILD_CONFIGURATION=Release
 RUN dotnet publish "Keda.Scaler.Functions.Worker.DurableTask.Examples.csproj" -c $BUILD_CONFIGURATION -warnaserror -o /app/publish /p:UseAppHost=false
 
-FROM mcr.microsoft.com/dotnet/sdk:8.0.201-cbl-mariner2.0-amd64@sha256:33d91a9dd7c3c5872d84a79878002bc6dcb17adb335ac32a41fff38e50e5f60d AS users
-RUN groupadd nonroot -g 2000 && \
-    useradd -r -M -s /sbin/nologin -g nonroot -c nonroot nonroot -u 1000
-
-FROM scratch AS nonroot
-COPY --from=users /etc/group /etc/group
-COPY --from=users /etc/passwd /etc/passwd
-
 FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0-mariner@sha256:3dd610034bc961733c3db9425d0d8a7c506d2c2bda7a064b7968451a47775373 AS runtime
-COPY --from=nonroot / /
-RUN chown -R nonroot:nonroot /azure-functions-host
+RUN chown -R $APP_UID /azure-functions-host
 ENV ASPNETCORE_URLS=http://+:8080 \
     AzureFunctionsJobHost__FileWatchingEnabled=false \
     AzureFunctionsJobHost__Logging__Console__IsEnabled=true \
@@ -30,9 +21,8 @@ ENV ASPNETCORE_URLS=http://+:8080 \
     AzureWebJobsScriptRoot=/home/site/wwwroot \
     DOTNET_EnableDiagnostics=0 \
     LANG=en_US.UTF-8 \
-    LC_ALL=en_US.UTF-8 \
     WEBSITE_HOSTNAME=localhost:8080
-USER nonroot
+USER $APP_UID
 EXPOSE 8080
 
 FROM runtime AS func

--- a/tests/Keda.Scaler.Functions.Worker.DurableTask.Examples/Dockerfile
+++ b/tests/Keda.Scaler.Functions.Worker.DurableTask.Examples/Dockerfile
@@ -19,7 +19,7 @@ FROM scratch AS nonroot
 COPY --from=users /etc/group /etc/group
 COPY --from=users /etc/passwd /etc/passwd
 
-FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated7.0-mariner@sha256:5a0ae4cab4ebd4f85e38fb9ed0e470059bd063ff7d0a668c197f5c1770ee721f AS runtime
+FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0-mariner@sha256:3dd610034bc961733c3db9425d0d8a7c506d2c2bda7a064b7968451a47775373 AS runtime
 COPY --from=nonroot / /
 RUN chown -R nonroot:nonroot /azure-functions-host
 ENV ASPNETCORE_URLS=http://+:8080 \

--- a/tests/Keda.Scaler.Functions.Worker.DurableTask.Examples/Dockerfile
+++ b/tests/Keda.Scaler.Functions.Worker.DurableTask.Examples/Dockerfile
@@ -21,6 +21,7 @@ ENV ASPNETCORE_URLS=http://+:8080 \
     AzureWebJobsScriptRoot=/home/site/wwwroot \
     DOTNET_EnableDiagnostics=0 \
     LANG=en_US.UTF-8 \
+    LC_ALL=en_US.UTF-8 \
     WEBSITE_HOSTNAME=localhost:8080
 USER $APP_UID
 EXPOSE 8080

--- a/tests/Keda.Scaler.Functions.Worker.DurableTask.Examples/Keda.Scaler.Functions.Worker.DurableTask.Examples.csproj
+++ b/tests/Keda.Scaler.Functions.Worker.DurableTask.Examples/Keda.Scaler.Functions.Worker.DurableTask.Examples.csproj
@@ -7,7 +7,6 @@
     <DockerfileContext>..\..</DockerfileContext>
     <Nullable>enable</Nullable>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Use `mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0-mariner@sha256:3dd610034bc961733c3db9425d0d8a7c506d2c2bda7a064b7968451a47775373` as base runtime image
- Use built-in `$APP_UID` for non-root user